### PR TITLE
Add flake8 for CI, fix its warnings

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,5 @@
+[flake8]
+max-line-length = 160
+exclude = tests/*
+max-complexity = 10
+ignore = W601, E402

--- a/cloudomate/gateway/bitpay.py
+++ b/cloudomate/gateway/bitpay.py
@@ -35,8 +35,8 @@ class BitPay(Gateway):
         print(base_url)
         invoice_id = uspl.query.split("=")[1]
 
-        # On the browser, users have to select between Bitcoin and Bitcoin cash 
-        # trigger bitcoin selection for successful transaction 
+        # On the browser, users have to select between Bitcoin and Bitcoin cash
+        # trigger bitcoin selection for successful transaction
         trigger_url = "{}/invoice-noscript?id={}&buyerSelectedTransactionCurrency=BTC".format(base_url, invoice_id)
         print(trigger_url)
         request.urlopen(trigger_url)

--- a/cloudomate/gateway/coingate.py
+++ b/cloudomate/gateway/coingate.py
@@ -4,7 +4,6 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import json
-from http.cookiejar import Cookie
 
 from fake_useragent import UserAgent
 from future import standard_library
@@ -47,7 +46,7 @@ class CoinGate(Gateway):
         response = browser.open(url, headers=headers)
         cookies = []
         for cookie in response.cookies:
-            cookie = cookie  # type: Cookie
+            cookie = cookie
             cookies.append('{}: {}'.format(cookie.name, cookie.value))
         ws = create_connection("wss://coingate.com/cable", cookie='; '.join(cookies), origin='https://coingate.com')
 

--- a/cloudomate/gateway/coinpayments.py
+++ b/cloudomate/gateway/coinpayments.py
@@ -3,17 +3,9 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import os
-from math import pow
-
-import electrum.bitcoin as bitcoin
-from electrum import paymentrequest as pr
 from future import standard_library
-from future.moves.urllib import request
-from future.moves.urllib.parse import urlsplit, parse_qs
 
 from cloudomate.gateway.gateway import Gateway, PaymentInfo
-from cloudomate.hoster.hoster import Hoster
 
 standard_library.install_aliases()
 
@@ -37,7 +29,7 @@ class CoinPayments(Gateway):
         :return: a tuple of the amount in BitCoin along with the address
         """
 
-        #select coin to pay
+        # select coin to pay
         browser.select_form(nr=0)
         form = browser.get_current_form()
         form['selcoin'] = 'BTC'
@@ -46,9 +38,9 @@ class CoinPayments(Gateway):
         form['last_name'] = settings.get('user', "lastname")
         form['email'] = settings.get('user', "email")
         form.set('screen_res', '1920x1080', force=True)
-        response = browser.submit_selected()
+        browser.submit_selected()
 
-        #go to actual payment page
+        # go to actual payment page
         browser.open("https://www.coinpayments.net/index.php?cmd=checkout")
         page = browser.get_current_page()
 

--- a/cloudomate/gateway/custom_mullvad.py
+++ b/cloudomate/gateway/custom_mullvad.py
@@ -3,10 +3,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import json
-
 from future import standard_library
-from future.moves.urllib import request
 
 from cloudomate.gateway.gateway import Gateway, PaymentInfo
 
@@ -22,12 +19,12 @@ class CustomMullvad(Gateway):
     def extract_info(page):
         """
         Extracts amount and BitCoin address from MullVad's payment page.
-        :param page: the HTML page returned after sumbitting the order 
+        :param page: the HTML page returned after sumbitting the order
         :return: a tuple of the amount in BitCoin along with the address
         """
         month_price = ""
         bitcoin_address = ""
-        
+
         # Parse page to get bitcoin ammount and address
         for line in page.split("\n"):
             if "1 month = " in line:
@@ -36,7 +33,7 @@ class CustomMullvad(Gateway):
                 bitcoin_address_line = line.strip().split(" ")[3].split("=")[1]
                 bitcoin_address = bitcoin_address_line.partition("\"")[-1]
                 bitcoin_address = bitcoin_address.rpartition("\"")[0]
- 
+
         return PaymentInfo(month_price, bitcoin_address)
 
     @staticmethod

--- a/cloudomate/gateway/gateway.py
+++ b/cloudomate/gateway/gateway.py
@@ -9,8 +9,6 @@ from collections import namedtuple
 from future import standard_library
 from future.utils import with_metaclass
 
-from mechanicalsoup import StatefulBrowser
-
 standard_library.install_aliases()
 
 PaymentInfo = namedtuple('PaymentInfo', ['amount', 'address'])

--- a/cloudomate/hoster/vpn/mullvad.py
+++ b/cloudomate/hoster/vpn/mullvad.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 from __future__ import division
-from __future__ import print_function 
+from __future__ import print_function
 from __future__ import unicode_literals
 
 import datetime
@@ -8,8 +8,8 @@ import os
 import shutil
 import sys
 import zipfile
-from builtins import round
 from builtins import float
+from builtins import round
 from builtins import str
 
 from forex_python.converter import CurrencyRates
@@ -22,9 +22,10 @@ from cloudomate.util.captchasolver import CaptchaSolver
 standard_library.install_aliases()
 
 if sys.version_info > (3, 0):
-   from urllib.request import urlretrieve
+    from urllib.request import urlretrieve
 else:
-   from urllib import urlretrieve
+    from urllib import urlretrieve
+
 
 class MullVad(VpnHoster):
     REGISTER_URL = "https://www.mullvad.net/en/account/create/"
@@ -85,8 +86,8 @@ class MullVad(VpnHoster):
 
         # Calculate the price in USD
         eur = float(string[string.index("€") + 1:string.index("/")])
-        price = round(CurrencyRates().convert("EUR","USD", eur), 2)
-        
+        price = round(CurrencyRates().convert("EUR", "USD", eur), 2)
+
         name, _ = cls.get_metadata()
         option = VpnOption(name, "OpenVPN", price, sys.maxsize, sys.maxsize)
         return [option]
@@ -112,11 +113,9 @@ class MullVad(VpnHoster):
 
         self.pay(wallet, self.get_gateway(), str(page))
 
-
     '''
     Hoster-specific methods that are needed to perform the actions
     '''
-
 
     def _register(self):
         self._browser.open(self.REGISTER_URL)
@@ -127,16 +126,16 @@ class MullVad(VpnHoster):
         img = soup.select("img.captcha")[0]["src"]
         urlretrieve("https://www.mullvad.net" + img,
                     "captcha.png")
-         
-        # Solve captcha 
+
+        # Solve captcha
         captcha_solver = CaptchaSolver(self._settings.get("anticaptcha",
                                                           "accountkey"))
         solution = captcha_solver.solve_captcha_text_case_sensitive(
-                                                                "./captcha.png")
+            "./captcha.png")
         form["captcha_1"] = solution
-        
+
         self._browser.session.headers["Referer"] = self._browser.get_url()
-      
+
         page = self._browser.submit_selected()
 
         # Check if registration was successful
@@ -146,7 +145,7 @@ class MullVad(VpnHoster):
             sys.exit(2)
 
         new_account_number = 0
-        
+
         # Parse page to get new account number
         new_page = str(self._browser.get_current_page())
         for line in new_page.split("\n"):
@@ -154,7 +153,7 @@ class MullVad(VpnHoster):
                 new_account_number = line.split(":")[1]
                 new_account_number = new_account_number.split("<")[0].strip(" ")
                 break
-        self._settings.put("user","accountnumber", new_account_number)
+        self._settings.put("user", "accountnumber", new_account_number)
         self._settings.save_settings()
 
         return page
@@ -162,7 +161,7 @@ class MullVad(VpnHoster):
     def _login(self):
         self._browser.open(self.LOGIN_URL)
         form = self._browser.select_form()
-        
+
         # Use account number to login
         form["account_number"] = self._settings.get("user", "accountnumber")
         self._browser.session.headers["Referer"] = self._browser.get_url()

--- a/cloudomate/hoster/vps/linevast.py
+++ b/cloudomate/hoster/vps/linevast.py
@@ -197,13 +197,7 @@ class LineVastClientArea(ClientArea):
         """
         Returns the parsed server information from email
         """
-        email_id = None
-        for email in self.get_emails():
-            e_id = email['id']
-            title = email['title']
-            if title == 'New Server Information':
-                email_id = e_id
-                break
+        email_id = self._get_email_id()
         self._browser.open(self.email_url + '?id=' + email_id)
         soup = self._browser.get_current_page()
 
@@ -236,6 +230,13 @@ class LineVastClientArea(ClientArea):
                 break
 
         return server_info
+
+    def _get_email_id(self):
+        for email in self.get_emails():
+            e_id = email['id']
+            title = email['title']
+            if title == 'New Server Information':
+                return e_id
 
     @staticmethod
     def _extract_emails(soup):

--- a/cloudomate/hoster/vps/routerhosting.py
+++ b/cloudomate/hoster/vps/routerhosting.py
@@ -3,18 +3,12 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import json
-import re
-import sys
-from builtins import round
 from builtins import super
 
-from currency_converter import CurrencyConverter
 from future import standard_library
 from mechanicalsoup.utils import LinkNotFoundError
 
 from cloudomate.gateway.coinpayments import CoinPayments
-from cloudomate.hoster.vps.clientarea import ClientArea
 from cloudomate.hoster.vps.solusvm_hoster import SolusvmHoster
 from cloudomate.hoster.vps.vps_hoster import VpsOption
 
@@ -83,7 +77,7 @@ class RouterHosting(SolusvmHoster):
         self._browser.follow_link(summary.find('a', class_='btn-checkout'))
 
         try:
-            form = self._browser.select_form(selector='form#frmCheckout')
+            self._browser.select_form(selector='form#frmCheckout')
         except LinkNotFoundError:
             print("Too many open transactions, try connecting from a different IP")
             raise
@@ -98,6 +92,7 @@ class RouterHosting(SolusvmHoster):
     '''
     Hoster-specific methods that are needed to perform the actions
     '''
+
     def _server_form(self):
         """
         Fills in the form containing server configuration.
@@ -128,7 +123,6 @@ class RouterHosting(SolusvmHoster):
                 memory=list_elements[0].text.strip().split('\xa0')[0],
                 bandwidth=list_elements[4].text.strip().split(' ')[0],
                 connection=list_elements[3].text.strip().split('Gbps')[0],
-                price= float(list_elements[6].text.split("\"")[0].split("/")[0][1:]),
+                price=float(list_elements[6].text.split("\"")[0].split("/")[0][1:]),
                 purchase_url=list_elements[7].find('a', {'class': 'w-btn'})['href'],
             )
-

--- a/cloudomate/test/test_captchasolver.py
+++ b/cloudomate/test/test_captchasolver.py
@@ -3,16 +3,11 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import unittest
-import time
 import os
 import unittest
 
-from mock import patch, MagicMock
 from future import standard_library
 from mock.mock import patch, MagicMock
-
-from cloudomate.util.captchasolver import CaptchaSolver, ReCaptchaSolver
 
 standard_library.install_aliases()
 

--- a/cloudomate/test/test_mullvad.py
+++ b/cloudomate/test/test_mullvad.py
@@ -3,12 +3,11 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import unittest
 import datetime
-from unittest import mock
+import unittest
 
 from future import standard_library
-from mock.mock import MagicMock 
+from mock.mock import MagicMock
 
 from cloudomate.hoster.vpn.mullvad import MullVad
 from cloudomate.hoster.vpn.vpn_hoster import VpnOption
@@ -19,7 +18,7 @@ standard_library.install_aliases()
 
 
 class TestMullvad(unittest.TestCase):
-     
+
     def setUp(self):
         self.settings = Settings()
         self.settings.put("user", "accountnumber", "2132sadfqf")
@@ -31,9 +30,9 @@ class TestMullvad(unittest.TestCase):
         self.mullvad._login = MagicMock()
         self.mullvad._order = MagicMock()
         self.mullvad.pay = MagicMock()
- 
+
         self.mullvad.purchase(self.wallet, self.option)
-        
+
         self.assertTrue(self.mullvad._login.called)
         self.assertTrue(self.mullvad._order.called)
         self.assertTrue(self.mullvad.pay.called)

--- a/cloudomate/util/captchasolver.py
+++ b/cloudomate/util/captchasolver.py
@@ -1,24 +1,22 @@
 from __future__ import absolute_import
 from __future__ import division
-from __future__ import print_function 
+from __future__ import print_function
 from __future__ import unicode_literals
-
-from builtins import open
-from builtins import str
 
 import base64
 import json
 import os
 import time
+from builtins import open
+from builtins import str
 
 import requests
-
 from future import standard_library
 
 standard_library.install_aliases()
 
 """
-Usage: 
+Usage:
 
 Feed Anti Captcha account API key to solver:
 c_solver = CaptchaSolver("fd58e13e22604e820052b44611d61d6c")
@@ -98,7 +96,7 @@ class CaptchaSolver(object):
         return solution["text"]
 
     def _get_task_result(self, task_id):
-        # Query API for the solution of the task       
+        # Query API for the solution of the task
         response = requests.post("https://api.anti-captcha.com/getTaskResult",
                                  json={"clientKey": self._client_key,
                                        "taskId": task_id})

--- a/cloudomate/util/settings.py
+++ b/cloudomate/util/settings.py
@@ -3,12 +3,14 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import os
+import sys
 from builtins import open
 from builtins import str
 from configparser import ConfigParser
 from configparser import NoOptionError
 
-from appdirs import *
+from appdirs import user_config_dir
 from future import standard_library
 
 standard_library.install_aliases()

--- a/cloudomate/wallet.py
+++ b/cloudomate/wallet.py
@@ -45,7 +45,7 @@ def determine_currency(text):
 def get_rate(currency='USD'):
     """
     Return price of 1 currency in BTC
-    Supported currencies available at 
+    Supported currencies available at
     http://forex-python.readthedocs.io/en/latest/currencysource.html#list-of-supported-currency-codes
     :param currency: currency to convert to
     :return: conversion rate from currency to BTC
@@ -140,21 +140,21 @@ class Wallet(object):
     def get_balance_confirmed(self):
         """
         Return confirmed balance of default electrum wallet
-        :return: 
+        :return:
         """
         return self.get_balance(confirmed=True, unconfirmed=False)
 
     def get_balance_unconfirmed(self):
         """
         Return unconfirmed balance of default electrum wallet
-        :return: 
+        :return:
         """
         return self.get_balance(confirmed=False, unconfirmed=True)
 
     def get_addresses(self):
         """
         Return the list of addresses of the default electrum wallet
-        :return: 
+        :return:
         """
         address_output = self.wallet_handler.get_addresses()
         return address_output
@@ -246,7 +246,7 @@ class ElectrumWalletHandler(object):
     def get_addresses(self):
         """
         Return the list of addresses of default wallet
-        :return: 
+        :return:
         """
         address = self._command(['listaddresses'])
         addr = json.loads(address)

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ setup(
 
     extras_require={
         'dev': [],
-        'test': ['mock', 'parameterized', 'flake8'],
+        'test': ['mock', 'parameterized'],
     },
 
     package_data=package_data,

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ setup(
 
     extras_require={
         'dev': [],
-        'test': ['mock', 'parameterized'],
+        'test': ['mock', 'parameterized', 'flake8'],
     },
 
     package_data=package_data,


### PR DESCRIPTION
Use flake8 to detect numerous formatting error in CI.

Currently disabled:
- ```W601: .has_key() is deprecated, use ‘in’``` - This is a custom method in our Config class.
- ```Module level import not at top of file``` - This is sometimes intended for Python2 compatibility

The max-line-length is currently set at a large 160 because the default of 79 causes a lot of warnings that wouldn't necessarily lead to code that's better readable. This is subject to change but I consider it out of scope of this PR currently.