### PR TITLE
add default reuse_session method implementation to Gateway

### DIFF
--- a/cloudomate/gateway/gateway.py
+++ b/cloudomate/gateway/gateway.py
@@ -23,6 +23,11 @@ class Gateway(with_metaclass(ABCMeta)):
 
     @staticmethod
     @abstractmethod
+    def reuse_session():
+        return False
+
+    @staticmethod
+    @abstractmethod
     def get_name():
         return ""
 


### PR DESCRIPTION
Purchase fails for any provider using any other gateway than CoinGate, because a `reuse_session` method was introduced and used in `Hoster.pay` without adding its implementation to other gateways. This PR fixes that by adding a default implementation to the `Gateway` class.

```
cloudomate vps purchase hostsailor 1
Selected configuration:
Name           CPU            RAM            Storage        Bandwidth      Price (USD)
Sailor         1              0.512          15             0.512          4.99
Purchase this option? (y/N) y
[ecc] info: libsecp256k1 library not available, falling back to python-ecdsa. This means signing operations will be slower.
[ecc] info: libsecp256k1 library not available, falling back to python-ecdsa. This means signing operations will be slower.
starting daemon (PID 49389)
[ecc] info: libsecp256k1 library not available, falling back to python-ecdsa. This means signing operations will be slower.
Password:
true
Payment link: https://coingate.com/invoice/64dbb1fc-5248-44e4-8a99-c5474e3efa49
Purchasing hostsailor instance
Traceback (most recent call last):
  File "/usr/local/bin/cloudomate", line 11, in <module>
    sys.exit(execute())
  File "/usr/local/lib/python2.7/site-packages/cloudomate/cmdline.py", line 80, in execute
    args.func(args)
  File "/usr/local/lib/python2.7/site-packages/cloudomate/cmdline.py", line 300, in purchase
    _purchase_vps(provider, user_settings, args)
  File "/usr/local/lib/python2.7/site-packages/cloudomate/cmdline.py", line 364, in _purchase_vps
    _register(provider, vps_option, user_settings)
  File "/usr/local/lib/python2.7/site-packages/cloudomate/cmdline.py", line 502, in _register
    provider_instance.purchase(wallet, vps_option)
  File "/usr/local/lib/python2.7/site-packages/cloudomate/hoster/vps/hostsailor.py", line 104, in purchase
    return self.pay(wallet, self.get_gateway(), payment_link)
  File "/usr/local/lib/python2.7/site-packages/cloudomate/hoster/hoster.py", line 92, in pay
    if gateway.reuse_session():
AttributeError: type object 'CoinGate' has no attribute 'reuse_session'
[ecc] info: libsecp256k1 library not available, falling back to python-ecdsa. This means signing operations will be slower.
Daemon stopped
```