### PR TITLE
Higher timeout for coingate purchasing

### DIFF
--- a/cloudomate/gateway/coingate.py
+++ b/cloudomate/gateway/coingate.py
@@ -85,7 +85,7 @@ class CoinGate(Gateway):
         debug_log.append('> ' + data3)
         ws.send(data3)
 
-        for i in range(0, 6):
+        for i in range(0, 20):
             result = ws.recv()
             debug_log.append('< ' + result)
             result_json = json.loads(result)


### PR DESCRIPTION
Fixes #63 

In the websockets implementation for CoinGate, the server sends pings to the client constantly, this PR heightens the timeout so that the wanted response can be sent within 20 pings instead of only 6.