### PR TITLE
Add error handling to undergroundprivate server form

### DIFF
--- a/cloudomate/hoster/vps/undergroundprivate.py
+++ b/cloudomate/hoster/vps/undergroundprivate.py
@@ -73,6 +73,10 @@ class UndergroundPrivate(SolusvmHoster):
     def purchase(self, wallet, option):
         self._browser.open(option.purchase_url)
         self._submit_server_form()
+        response_text = self._browser.get_current_page().text.strip()
+        if response_text:
+            print(response_text)
+            return
         self._browser.open(self.CART_URL)
         self._submit_user_form()
 


### PR DESCRIPTION
Fixes #67 

The _submit_server_form function calls a page that returns a list of errors. Print the errors and fail if there's any.