### PR TITLE
remove bandwidth units from vps options

### DIFF
--- a/cloudomate/hoster/vps/libertyvps.py
+++ b/cloudomate/hoster/vps/libertyvps.py
@@ -128,7 +128,7 @@ class LibertyVPS(SolusvmHoster):
                 storage=list_elements[2].text.strip().split('GB')[0],
                 cores=list_elements[0].text.strip().split(' ')[0].split('\xa0')[0],
                 memory=list_elements[1].text.strip().split(' ')[0],
-                bandwidth=list_elements[3].text.strip(),
+                bandwidth=list_elements[3].text.replace('TB', '').strip(),
                 connection=list_elements[4].text.strip().split('Gbps')[0],
                 price=float(header_elements[1].text[1:]),
                 purchase_url=link_element.find('a')['href'],

--- a/cloudomate/hoster/vps/linevast.py
+++ b/cloudomate/hoster/vps/linevast.py
@@ -139,7 +139,7 @@ class LineVast(SolusvmHoster):
                 storage=list_elements[2].text.strip().split(' ')[0].split('GB')[0],
                 cores=list_elements[0].text.strip().split(' ')[0],
                 memory=list_elements[1].text.strip().split(' ')[0],
-                bandwidth='unmetered',
+                bandwidth=sys.maxsize,
                 connection=1,
                 price=price_usd,
                 purchase_url='https://panel.linevast.de' + option.find('a', {'class': 'order-button'})['href'],

--- a/cloudomate/hoster/vps/routerhosting.py
+++ b/cloudomate/hoster/vps/routerhosting.py
@@ -121,7 +121,7 @@ class RouterHosting(SolusvmHoster):
                 storage=list_elements[2].text.strip().split('GB')[0],
                 cores=list_elements[1].text.strip().split(' ')[0].split('\xa0')[0],
                 memory=list_elements[0].text.strip().split('\xa0')[0],
-                bandwidth=list_elements[4].text.strip().split(' ')[0],
+                bandwidth=list_elements[4].text.strip().split(' ')[0].replace('TB', ''),
                 connection=list_elements[3].text.strip().split('Gbps')[0],
                 price=float(list_elements[6].text.split("\"")[0].split("/")[0][1:]),
                 purchase_url=list_elements[7].find('a', {'class': 'w-btn'})['href'],

--- a/cloudomate/hoster/vps/twosync.py
+++ b/cloudomate/hoster/vps/twosync.py
@@ -8,6 +8,8 @@ import time
 from builtins import int
 from builtins import super
 
+from sys import maxsize
+
 from future import standard_library
 from mechanicalsoup.utils import LinkNotFoundError
 
@@ -179,7 +181,7 @@ class TwoSync(SolusvmHoster):
             storage=option['Space'].split('GB')[0],
             cores=option['CPU'],
             memory=option['RAM'].split('GB')[0],
-            bandwidth=option['Bandwidth'].lower(),
+            bandwidth=maxsize,
             connection=int(option['Port'].split('Gbit')[0]),
             price=float(option['price']),
             purchase_url=option['purchase_url'],


### PR DESCRIPTION
The bandwidth returned in options should be a value in TB without units.
In case of unmetered bandwidth, the value should be `sys.maxsize`.